### PR TITLE
Add cli interface

### DIFF
--- a/jaiqu/cli.py
+++ b/jaiqu/cli.py
@@ -1,0 +1,59 @@
+import json
+import sys
+
+from typer import Option, Typer
+
+from .jaiqu import translate_schema
+
+typer_app = Typer()
+
+
+@typer_app.command()
+def jaiqu(
+    schema_file: str = Option(..., "-s", "--schema", help="Json schema file path"),
+    data_file: str = Option(
+        None,
+        "-d",
+        "--data",
+        help="Json data file path. if not passed will try to read from stdin",
+    ),
+    quiet: bool = Option(False, "-q", "--quiet", help="Quiet mode, only print errors"),
+    key_hints: str = Option(
+        None,
+        "-k",
+        "--key-hints",
+        help="Extra prompt for the ai to help it complete the task",
+    ),
+):
+    """
+    Validate and translate a json schema to jq filter
+    """
+    with open(schema_file) as f:
+        output_schema = json.load(f)
+    if data_file is None:
+        if sys.stdin.isatty():
+            sys.exit("Error: No data piped to stdin.")
+        else:
+            if not quiet:
+                print("--data not provided, reading from stdin")
+            data_file = sys.stdin.read()
+            input_json = json.loads(data_file)
+    else:
+        with open(data_file) as f:
+            input_json = json.load(f)
+
+    query = translate_schema(
+        output_schema=output_schema,
+        input_json=input_json,
+        key_hints=key_hints,
+        quiet=quiet,
+    )
+    print(query)
+
+
+def main():
+    typer_app()
+
+
+if __name__ == "__main__":
+    main()

--- a/jaiqu/cli.py
+++ b/jaiqu/cli.py
@@ -24,6 +24,12 @@ def jaiqu(
         "--key-hints",
         help="Extra prompt for the ai to help it complete the task",
     ),
+    max_retries: int = Option(
+        10,
+        "-r",
+        "--max-retries",
+        help="Max number of retries for the ai to complete the task",
+    ),
 ):
     """
     Validate and translate a json schema to jq filter
@@ -46,7 +52,8 @@ def jaiqu(
         output_schema=output_schema,
         input_json=input_json,
         key_hints=key_hints,
-        quiet=quiet,
+        max_retries=max_retries,
+        quiet=quiet
     )
     print(query)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ classifiers = [
 dependencies = [
     "jq==1.6.0",
     "openai~=1.12.0",
-    "jsonschema==4.21.1"
+    "jsonschema==4.21.1",
+    "typer==0.9.0",
 ]
 
 [project.optional-dependencies]
@@ -34,3 +35,6 @@ dev = [
 [project.urls]
 Homepage = "https://github.com/AgentOps-AI/Jaiqu"
 Issues = "https://github.com/AgentOps-AI/Jaiqu/issues"
+
+[project.entry-points.console_scripts]
+jaiqu = "jaiqu.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,6 @@ Issues = "https://github.com/AgentOps-AI/Jaiqu/issues"
 
 [project.entry-points.console_scripts]
 jaiqu = "jaiqu.cli:main"
+
+[tool.setuptools]
+packages = { find = { where = ["."], exclude = ["samples"] } }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jaiqu"
-version = "0.0.4"
+version = "0.0.5"
 authors = [
   { name = "Alex Reibman", email = "areibman@gmail.com" },
   { name = "Howard Gil", email = "howardbgil@gmail.com" },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 jq==1.6.0
 openai>=1.12.0,<2.0.0
 jsonschema==4.21.1
+typer==0.9.0

--- a/samples/data.json
+++ b/samples/data.json
@@ -1,0 +1,11 @@
+{
+    "call.id": "123",
+    "datetime": "2022-01-01",
+    "timestamp": 1640995200,
+    "Address": "123 Main St",
+    "user": {
+        "name": "John Doe",
+        "age": 30,
+        "contact": "john@email.com"
+    }
+}

--- a/samples/schema.json
+++ b/samples/schema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": ["string", "null"],
+            "description": "A unique identifier for the record."
+        },
+        "date": {
+            "type": "string",
+            "description": "A string describing the date."
+        },
+        "model": {
+            "type": "string",
+            "description": "A text field representing the model used."
+        }
+    },
+    "required": [
+        "id",
+        "date"
+    ]
+}


### PR DESCRIPTION
Awesome project! I thought it would be useful to use this in the cli, to allow chaining with jq, curl, etc

So I added a simple cli interface over the base library, here's how to use it:

In root folder:
```sh
pip install -e .
jaiqu --help
cat samples/data.json | jaiqu -s samples/schema.json
# OR
jaiqu -s samples/schema.json -d samples/data.json

# Example with all the flags, 
# and testing the output with jq itself and the same data

cat samples/data.json | jaiqu \
    -k "We are processing outputs of an containing an id and a date of a user." \
    -s samples/schema.json -q \
    | xargs \
        -I {} \
        bash -c 'echo "{}" && cat samples/data.json | jq "{}"' 
```

Example: 

![CleanShot 2024-04-01 at 14 50 41@2x](https://github.com/AgentOps-AI/Jaiqu/assets/98129582/ecd3f046-0d31-49a1-8913-3fcf81cc4bf5)

With --quiet:
![CleanShot 2024-04-01 at 14 52 58@2x](https://github.com/AgentOps-AI/Jaiqu/assets/98129582/77196cae-80ad-4d36-84cd-048e02f939eb)
