### PR TITLE
feat(cli): adding command execution to command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,29 @@ jq_query = jaiqu.translate_schema(input_json, schema, key_hints, max_retries=30)
 >>>'{"id": .attributes["call.id"], "date": .datetime}'
 ```
 
+### CLI Usage
+
+```bash
+git clone https://github.com/AgentOps-AI/Jaiqu.git
+cd Jaiqu/samples/
+
+jaiqu -s schema.json -d data.json
+# Validating schema: 100%|███████████████████████████| 3/3 [00:11<00:00,  3.73s/it, Key: model]
+# Translating schema: 100%|███████████████████████████| 2/2 [00:02<00:00,  1.46s/it, Key: date]
+# Retry attempts:  20%|███████████████████▌                     | 2/10 [00:02<00:11,  1.46s/it]
+# Validation attempts:  10%|█████████▎                          | 1/10 [00:00<00:08,  1.02it/s]
+
+# Query:           { "id": (.["call.id"] // null | tostring), "date": (.["datetime"] // null) }
+# Full completion: jq '{ "id": (.["call.id"] // null | tostring), "date": (.["datetime"] // null) }' data.json
+# [E]xecute, [A]bort: e
+# {
+#   "id": "123",
+#   "date": "2022-01-01"
+# }
+```
+
+> Note: usage is currently limited to python 3.9 & 3.10
+
 ## Installation
 
 #### Recommended: [PyPI](https://pypi.org/project/jaiqu/):

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ jaiqu -s schema.json -d data.json
 # Retry attempts:  20%|███████████████████▌                     | 2/10 [00:02<00:11,  1.46s/it]
 # Validation attempts:  10%|█████████▎                          | 1/10 [00:00<00:08,  1.02it/s]
 
-# Query:           { "id": (.["call.id"] // null | tostring), "date": (.["datetime"] // null) }
-# Full completion: jq '{ "id": (.["call.id"] // null | tostring), "date": (.["datetime"] // null) }' data.json
+jq '{ "id": (if .["call.id"] then .["call.id"] else null end), "date": (if has("datetime") then .datetime else "None" end) }' data.json
+# Run command?
 # [E]xecute, [A]bort: e
 # {
 #   "id": "123",

--- a/jaiqu/cli.py
+++ b/jaiqu/cli.py
@@ -1,9 +1,12 @@
 import json
 import sys
 
+import typer
 from typer import Option, Typer
+from click.types import Choice
 
 from .jaiqu import translate_schema
+from .helpers import run_command
 
 typer_app = Typer()
 
@@ -55,7 +58,17 @@ def jaiqu(
         max_retries=max_retries,
         quiet=quiet
     )
-    print(query)
+    full_completion = f"jq '{query}' {data_file}"
+    print(f"\n{full_completion}\nRun command?")
+    option = typer.prompt(
+        text="[E]xecute, [A]bort",
+        type=Choice(("e", "a"), case_sensitive=False),
+        default="e",
+        show_choices=False,
+        show_default=False,
+    )
+    if option in ("e"):
+        run_command(full_completion)
 
 
 def main():

--- a/jaiqu/jaiqu.py
+++ b/jaiqu/jaiqu.py
@@ -78,7 +78,8 @@ def translate_schema(input_json, output_schema, openai_api_key: str | None = Non
             pbar.set_postfix_str(f"Key: {key}", refresh=True)
             jq_string = create_jq_string(input_json, key, value, openai_api_key)
 
-            if jq_string == "None":  # If the response is empty, skip the key
+            # If the response is empty, skip the key
+            if jq_string == "None":
                 pbar.update(1)
                 continue
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,7 @@ dev = [
 Homepage = "https://github.com/AgentOps-AI/Jaiqu"
 Issues = "https://github.com/AgentOps-AI/Jaiqu/issues"
 
-# [project.entry-points.console_scripts]
-[project.scripts]
+[project.entry-points.console_scripts]
 jaiqu = "jaiqu.cli:main"
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dev = [
 Homepage = "https://github.com/AgentOps-AI/Jaiqu"
 Issues = "https://github.com/AgentOps-AI/Jaiqu/issues"
 
-[project.entry-points.console_scripts]
+# [project.entry-points.console_scripts]
+[project.scripts]
 jaiqu = "jaiqu.cli:main"
 
 [tool.setuptools]


### PR DESCRIPTION
## summary

I had varied results getting jaiqu working locally with `python 3.12` and `gpt-4-0125-preview` -- where it would frequently exceed retries in validating the query and error out. once I changed over to `3.10` and the `gpt-4o` model it gave more consistent results

## changes

- added cli instructions to readme
- added `run_command()` method to the end of `main()`